### PR TITLE
Change http to https in D3 refs to prevent browsers from blocking mix…

### DIFF
--- a/_includes/d3/rc_natural_response_general.html
+++ b/_includes/d3/rc_natural_response_general.html
@@ -35,7 +35,7 @@
 
 <body>
   <div id="rc-natural-general-d3"></div>
-  <script src="http://d3js.org/d3.v4.min.js"></script>
+  <script src="https://d3js.org/d3.v4.min.js"></script>
   <script>
   var margin = { top:0, right:0, bottom:0, left:0 };  // margin outside border
   var padding = { top:40, right:60, bottom:40, left:60 };  // padding inside border

--- a/_includes/d3/rc_natural_response_general_p.html
+++ b/_includes/d3/rc_natural_response_general_p.html
@@ -35,7 +35,7 @@
 
 <body>
   <div id="rc-natural-general-p-d3"></div>
-  <script src="http://d3js.org/d3.v4.min.js"></script>
+  <script src="https://d3js.org/d3.v4.min.js"></script>
   <script>
   var margin = { top:0, right:0, bottom:0, left:0 };  // margin outside border
   var padding = { top:40, right:60, bottom:40, left:60 };  // padding inside border

--- a/_includes/d3/rc_natural_response_s.html
+++ b/_includes/d3/rc_natural_response_s.html
@@ -39,7 +39,7 @@
 
 <body>
   <div id="rc-natural-s-d3"></div>
-  <script src="http://d3js.org/d3.v4.min.js"></script>
+  <script src="https://d3js.org/d3.v4.min.js"></script>
   <script>
   var margin = { top:0, right:0, bottom:0, left:0 };  // margin outside border
   var padding = { top:40, right:100, bottom:40, left:40 };  // padding inside border

--- a/_includes/d3/rc_natural_response_v.html
+++ b/_includes/d3/rc_natural_response_v.html
@@ -35,7 +35,7 @@
 
 <body>
   <div id="rc-natural-v-d3"></div>
-  <script src="http://d3js.org/d3.v4.min.js"></script>
+  <script src="https://d3js.org/d3.v4.min.js"></script>
   <script>
   var margin = { top:0, right:0, bottom:0, left:0 };  // margin outside border
   var padding = { top:40, right:100, bottom:40, left:40 };  // padding inside border

--- a/_includes/d3/rc_step_forced_general.html
+++ b/_includes/d3/rc_step_forced_general.html
@@ -35,7 +35,7 @@
 
 <body>
   <div id="rc-forced-general-d3"></div>
-  <script src="http://d3js.org/d3.v4.min.js"></script>
+  <script src="https://d3js.org/d3.v4.min.js"></script>
   <script>
     var margin = { top:0, right:0, bottom:0, left:0 };  // margin outside border
     var padding = { top:40, right:60, bottom:40, left:60 };  // padding inside border

--- a/_includes/d3/rc_step_forced_response.html
+++ b/_includes/d3/rc_step_forced_response.html
@@ -26,7 +26,7 @@ svg text {
 </head>
 <body>
   <div id="rc-step-forced-d3"></div>
-  <script src="http://d3js.org/d3.v4.min.js"></script>
+  <script src="https://d3js.org/d3.v4.min.js"></script>
   <script>
     var margin = { top:0, right:0, bottom:0, left:0 };  // margin outside border
     var padding = { top:40, right:60, bottom:40, left:60 };  // padding inside border

--- a/_includes/d3/rc_step_natural_response_Kn.html
+++ b/_includes/d3/rc_step_natural_response_Kn.html
@@ -35,7 +35,7 @@
 
 <body>
 <div id="rc-natural-Kn-d3"></div>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
   var margin = { top:0, right:0, bottom:0, left:0 };  // margin outside border

--- a/_includes/d3/rc_step_response_Agarwal.html
+++ b/_includes/d3/rc_step_response_Agarwal.html
@@ -35,7 +35,7 @@
 
 <body>
   <div id="rc-step-Agarwal-d3"></div>
-  <script src="http://d3js.org/d3.v4.min.js"></script>
+  <script src="https://d3js.org/d3.v4.min.js"></script>
   <script>
   var margin = { top:0, right:0, bottom:0, left:0 };  // margin outside border
   var padding = { top:40, right:60, bottom:40, left:60 };  // padding inside border

--- a/_includes/d3/rc_step_response_Sadiku.html
+++ b/_includes/d3/rc_step_response_Sadiku.html
@@ -35,7 +35,7 @@
 
 <body>
   <div id="rc-step-Sadiku-d3"></div>
-  <script src="http://d3js.org/d3.v4.min.js"></script>
+  <script src="https://d3js.org/d3.v4.min.js"></script>
   <script>
   var margin = { top:0, right:0, bottom:0, left:0 };  // margin outside border
   var padding = { top:40, right:60, bottom:40, left:60 };  // padding inside border

--- a/_includes/d3/rc_step_response_general.html
+++ b/_includes/d3/rc_step_response_general.html
@@ -35,7 +35,7 @@
 
 <body>
   <div id="rc-step-general-d3"></div>
-  <script src="http://d3js.org/d3.v4.min.js"></script>
+  <script src="https://d3js.org/d3.v4.min.js"></script>
   <script>
   var margin = { top:0, right:0, bottom:0, left:0 };  // margin outside border
   var padding = { top:40, right:60, bottom:40, left:60 };  // padding inside border

--- a/_includes/d3/rc_step_response_total.html
+++ b/_includes/d3/rc_step_response_total.html
@@ -35,7 +35,7 @@
 
 <body>
   <div id="rc-step-total-d3"></div>
-  <script src="http://d3js.org/d3.v4.min.js"></script>
+  <script src="https://d3js.org/d3.v4.min.js"></script>
   <script>
   var margin = { top:0, right:0, bottom:0, left:0 };  // margin outside border
   var padding = { top:40, right:60, bottom:40, left:60 };  // padding inside border

--- a/_includes/d3/rc_step_response_total0.html
+++ b/_includes/d3/rc_step_response_total0.html
@@ -35,7 +35,7 @@
 
 <body>
   <div id="rc-step-total0-d3"></div>
-  <script src="http://d3js.org/d3.v4.min.js"></script>
+  <script src="https://d3js.org/d3.v4.min.js"></script>
   <script>
   var margin = { top:0, right:0, bottom:0, left:0 };  // margin outside border
   var padding = { top:40, right:60, bottom:40, left:60 };  // padding inside border

--- a/assets/d3/_README.md
+++ b/assets/d3/_README.md
@@ -1,6 +1,6 @@
 # Spinning Numbers D3.js graphs
 
-This repository contains the code for static images (graphs) for spinningnumbers.org. The images are created with [D3.js](http://d3js.org). I chose this as an alternative to Khan Academy's [graphie](http://graphie-to-png.kasandbox.org/) program. I use D3js for static and animated graphs that require computed waveforms like exponentials or sines.
+This repository contains the code for static images (graphs) for spinningnumbers.org. The images are created with [D3.js](https://d3js.org). I chose this as an alternative to Khan Academy's [graphie](http://graphie-to-png.kasandbox.org/) program. I use D3js for static and animated graphs that require computed waveforms like exponentials or sines.
 
 ## D3 static images
 

--- a/assets/d3/capacitor_in_action_current_pulse.html
+++ b/assets/d3/capacitor_in_action_current_pulse.html
@@ -35,7 +35,7 @@ svg text {
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/capacitor_in_action_voltage_ramp.html
+++ b/assets/d3/capacitor_in_action_voltage_ramp.html
@@ -36,7 +36,7 @@ svg text {
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/constant_current_source.html
+++ b/assets/d3/constant_current_source.html
@@ -36,7 +36,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/constant_voltage_source.html
+++ b/assets/d3/constant_voltage_source.html
@@ -35,7 +35,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/diode_equation.html
+++ b/assets/d3/diode_equation.html
@@ -35,7 +35,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/diode_equation_LED.html
+++ b/assets/d3/diode_equation_LED.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/diode_equation_LED_brighter.html
+++ b/assets/d3/diode_equation_LED_brighter.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/diode_equation_LED_noresistor.html
+++ b/assets/d3/diode_equation_LED_noresistor.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/diode_equation_closeup.html
+++ b/assets/d3/diode_equation_closeup.html
@@ -35,7 +35,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/diode_equation_temperature.html
+++ b/assets/d3/diode_equation_temperature.html
@@ -35,7 +35,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/diode_iv_curve.html
+++ b/assets/d3/diode_iv_curve.html
@@ -35,7 +35,7 @@ svg text {
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/diode_iv_curve2.html
+++ b/assets/d3/diode_iv_curve2.html
@@ -35,7 +35,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/fourquadrantplot.html
+++ b/assets/d3/fourquadrantplot.html
@@ -33,7 +33,7 @@ text {
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/inductor_in_action_current_ramp.html
+++ b/assets/d3/inductor_in_action_current_ramp.html
@@ -36,7 +36,7 @@ svg text {
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/lc_natural_response_both.html
+++ b/assets/d3/lc_natural_response_both.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/lc_natural_response_current.html
+++ b/assets/d3/lc_natural_response_current.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/lc_natural_response_current_closeup.html
+++ b/assets/d3/lc_natural_response_current_closeup.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/lc_natural_response_intuition.html
+++ b/assets/d3/lc_natural_response_intuition.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/lc_natural_response_voltage.html
+++ b/assets/d3/lc_natural_response_voltage.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/linearity_3x_slope.html
+++ b/assets/d3/linearity_3x_slope.html
@@ -36,7 +36,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/linearity_capacitor_slope.html
+++ b/assets/d3/linearity_capacitor_slope.html
@@ -36,7 +36,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/linearity_inductor_slope.html
+++ b/assets/d3/linearity_inductor_slope.html
@@ -36,7 +36,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/linearity_x-squared.html
+++ b/assets/d3/linearity_x-squared.html
@@ -36,7 +36,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/logarithm.html
+++ b/assets/d3/logarithm.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/rc_natural_response_complete.html
+++ b/assets/d3/rc_natural_response_complete.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/rc_natural_response_ex1.html
+++ b/assets/d3/rc_natural_response_ex1.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/rc_natural_response_ex2.html
+++ b/assets/d3/rc_natural_response_ex2.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/rc_natural_response_voltage.html
+++ b/assets/d3/rc_natural_response_voltage.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/rc_step_intuition.html
+++ b/assets/d3/rc_step_intuition.html
@@ -34,7 +34,7 @@ svg text {
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/rc_step_natural_response.html
+++ b/assets/d3/rc_step_natural_response.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/rc_step_natural_response_Kn.html
+++ b/assets/d3/rc_step_natural_response_Kn.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/resistor_i-v_plot.html
+++ b/assets/d3/resistor_i-v_plot.html
@@ -36,7 +36,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/rl_natural_response_current.html
+++ b/assets/d3/rl_natural_response_current.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/rl_natural_response_current_nolabel.html
+++ b/assets/d3/rl_natural_response_current_nolabel.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/rl_natural_response_voltage.html
+++ b/assets/d3/rl_natural_response_voltage.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/rl_natural_response_voltage_nolabel.html
+++ b/assets/d3/rl_natural_response_voltage_nolabel.html
@@ -35,7 +35,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/rlc_3variations_current.html
+++ b/assets/d3/rlc_3variations_current.html
@@ -35,7 +35,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/rlc_critically_damped_current_I.html
+++ b/assets/d3/rlc_critically_damped_current_I.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/rlc_critically_damped_current_V.html
+++ b/assets/d3/rlc_critically_damped_current_V.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/rlc_natural_response_intuition.html
+++ b/assets/d3/rlc_natural_response_intuition.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/rlc_overdamped_current.html
+++ b/assets/d3/rlc_overdamped_current.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/rlc_underdamped_current.html
+++ b/assets/d3/rlc_underdamped_current.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/rlc_underdamped_voltages.html
+++ b/assets/d3/rlc_underdamped_voltages.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/rms2.html
+++ b/assets/d3/rms2.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/rms3.html
+++ b/assets/d3/rms3.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/rms4.html
+++ b/assets/d3/rms4.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/rms5.html
+++ b/assets/d3/rms5.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/rms6.html
+++ b/assets/d3/rms6.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/rms7.html
+++ b/assets/d3/rms7.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/sawtooth_voltage_source.html
+++ b/assets/d3/sawtooth_voltage_source.html
@@ -36,7 +36,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/square_voltage_source.html
+++ b/assets/d3/square_voltage_source.html
@@ -34,7 +34,7 @@ svg text {
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/step_voltage_source.html
+++ b/assets/d3/step_voltage_source.html
@@ -35,7 +35,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/thevenin1.html
+++ b/assets/d3/thevenin1.html
@@ -34,7 +34,7 @@ svg text {
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/thevenin3.html
+++ b/assets/d3/thevenin3.html
@@ -34,7 +34,7 @@ svg text {
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/thevenin6.html
+++ b/assets/d3/thevenin6.html
@@ -34,7 +34,7 @@ svg text {
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/thevenin8.html
+++ b/assets/d3/thevenin8.html
@@ -34,7 +34,7 @@ svg text {
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/thevenin8a.html
+++ b/assets/d3/thevenin8a.html
@@ -34,7 +34,7 @@ svg text {
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/thevenin_blank_graph.html
+++ b/assets/d3/thevenin_blank_graph.html
@@ -34,7 +34,7 @@ svg text {
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/triangle_voltage_source.html
+++ b/assets/d3/triangle_voltage_source.html
@@ -36,7 +36,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/

--- a/assets/d3/variable_voltage_source.html
+++ b/assets/d3/variable_voltage_source.html
@@ -35,7 +35,7 @@
 </head>
 
 <body>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 
 <script>
 // http://rajapradhan.com/blogs/d3-js-v4-essentials/axes/


### PR DESCRIPTION
…ed content

I couldn't see the charts on the RC Step Response page because Firefox blocks http refs on https pages, so I just ran a search and replace for `http://d3js.org` to `https://d3js.org` and confirmed it was fixed with jekyll serve.

Thank you so much for making this wonderful site, I'm learning EE as a hobby and when I found this site it blew me away!